### PR TITLE
Update prefixes to Dec. 2022 BIPM SI 9th Ed. V2.01

### DIFF
--- a/vocab/prefixes/VOCAB_QUDT-PREFIXES-v2.1.ttl
+++ b/vocab/prefixes/VOCAB_QUDT-PREFIXES-v2.1.ttl
@@ -13,7 +13,7 @@
 <http://qudt.org/2.1/vocab/prefix>
   a owl:Ontology ;
   vaem:hasGraphMetadata vaem:GMD_QUDT-PREFIXES ;
-  rdfs:label "QUDT VOCAB Decimal Prefixes Release 2.1.29" ;
+  rdfs:label "QUDT VOCAB Decimal Prefixes Release 2.1.30" ;
   owl:imports <http://qudt.org/2.1/schema/facade/qudt> ;
   owl:versionIRI <http://qudt.org/2.1/vocab/prefix> ;
   owl:versionInfo "Created with TopBraid Composer" ;
@@ -253,6 +253,54 @@ prefix:Pico
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/prefix> ;
   rdfs:label "Pico"@en ;
 .
+prefix:Quecto
+  a qudt:DecimalPrefix ;
+  a qudt:Prefix ;
+  dcterms:description "'quecto' is a decimal prefix for expressing a value with a scaling of \\(10^{-30}\\)."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Quecto"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.nist.gov/pml/owm/metric-si-prefixes"^^xsd:anyURI ;
+  qudt:prefixMultiplier 1.0E-30 ;
+  qudt:symbol "q" ;
+  qudt:ucumCode "q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/prefix> ;
+  rdfs:label "Quecto"@en ;
+.
+prefix:Quetta
+  a qudt:DecimalPrefix ;
+  a qudt:Prefix ;
+  dcterms:description "'quetta' is a decimal prefix for expressing a value with a scaling of \\(10^{30}\\)."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Quetta"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.nist.gov/pml/owm/metric-si-prefixes"^^xsd:anyURI ;
+  qudt:prefixMultiplier 1.0E30 ;
+  qudt:symbol "Q" ;
+  qudt:ucumCode "Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/prefix> ;
+  rdfs:label "Quetta"@en ;
+.
+prefix:Ronna
+  a qudt:DecimalPrefix ;
+  a qudt:Prefix ;
+  dcterms:description "'ronna' is a decimal prefix for expressing a value with a scaling of \\(10^{27}\\)."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ronna"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.nist.gov/pml/owm/metric-si-prefixes"^^xsd:anyURI ;
+  qudt:prefixMultiplier 1.0E27 ;
+  qudt:symbol "R" ;
+  qudt:ucumCode "R" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/prefix> ;
+  rdfs:label "Ronna"@en ;
+.
+prefix:Ronto
+  a qudt:DecimalPrefix ;
+  a qudt:Prefix ;
+  dcterms:description "'ronto' is a decimal prefix for expressing a value with a scaling of \\(10^{-27}\\)."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ronto"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.nist.gov/pml/owm/metric-si-prefixes"^^xsd:anyURI ;
+  qudt:prefixMultiplier 1.0E-27 ;
+  qudt:symbol "r" ;
+  qudt:ucumCode "r" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/prefix> ;
+  rdfs:label "Ronto"@en ;
+.
 prefix:Tebi
   a qudt:BinaryPrefix ;
   a qudt:Prefix ;
@@ -345,15 +393,16 @@ vaem:GMD_QUDT-PREFIXES
   dcterms:contributor "Jack Hodges" ;
   dcterms:contributor "Ralph Hodgson" ;
   dcterms:contributor "Steve Ray" ;
+  dcterms:contributor "Michael Ringel" ;
   dcterms:created "2020-07-15"^^xsd:date ;
   dcterms:creator "Steve Ray" ;
-  dcterms:modified "2023-07-28T10:54:47.359-04:00"^^xsd:dateTime ;
+  dcterms:modified "2023-08-11T10:39:23.751+00:00"^^xsd:dateTime ;
   dcterms:rights "The QUDT Ontologies are issued under a Creative Commons Attribution 4.0 International License (CC BY 4.0), available at https://creativecommons.org/licenses/by/4.0/. Attribution should be made to QUDT.org" ;
   dcterms:subject "Prefixes" ;
   dcterms:title "QUDT Prefixes Version 2.1 Vocabulary" ;
   vaem:description "The Prefixes vocabulary defines the prefixes commonly prepended to units to connote multiplication, either decimal or binary." ;
   vaem:graphName "prefix" ;
-  vaem:graphTitle "QUDT Prefixes Version 2.1.29" ;
+  vaem:graphTitle "QUDT Prefixes Version 2.1.30" ;
   vaem:hasGraphRole vaem:VocabularyGraph ;
   vaem:hasOwner <http://www.linkedmodel.org/schema/vaem#QUDT.org> ;
   vaem:hasSteward <http://www.linkedmodel.org/schema/vaem#QUDT.org> ;
@@ -376,5 +425,5 @@ vaem:GMD_QUDT-PREFIXES
   vaem:usesNonImportedResource dcterms:title ;
   vaem:website "http://qudt.org/2.1/vocab/prefix.ttl"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/prefix> ;
-  rdfs:label "QUDT Prefix Vocabulary Version Metadata 2.1.29" ;
+  rdfs:label "QUDT Prefix Vocabulary Version Metadata 2.1.30" ;
 .


### PR DESCRIPTION
New prefixes have been added in the December 2022 update of the BIPM SI Brochure (9th Edition, December 2022, V2.01), specifically (see https://www.bipm.org/en/measurement-units/si-prefixes):

1.) quetta (symbol: "Q"; multiplying factor 10^30),
2.) ronna (symbol: "R"; multiplying factor 10^27),
3.) ronto (symbol: "r"; multiplying factor 10^-27) and
4.) quecto (symbol: "q"; multiplying factor 10^-30)

Note: I do not know if the updates to the GMD_QUDT-PREFIXES metadata and perfixes version bump are acceptable, please check.