### PR TITLE
Revert Prefix Vocabulary Version Metadata Version Bump

### DIFF
--- a/vocab/prefixes/VOCAB_QUDT-PREFIXES-v2.1.ttl
+++ b/vocab/prefixes/VOCAB_QUDT-PREFIXES-v2.1.ttl
@@ -13,7 +13,7 @@
 <http://qudt.org/2.1/vocab/prefix>
   a owl:Ontology ;
   vaem:hasGraphMetadata vaem:GMD_QUDT-PREFIXES ;
-  rdfs:label "QUDT VOCAB Decimal Prefixes Release 2.1.30" ;
+  rdfs:label "QUDT VOCAB Decimal Prefixes Release 2.1.29" ;
   owl:imports <http://qudt.org/2.1/schema/facade/qudt> ;
   owl:versionIRI <http://qudt.org/2.1/vocab/prefix> ;
   owl:versionInfo "Created with TopBraid Composer" ;
@@ -396,13 +396,13 @@ vaem:GMD_QUDT-PREFIXES
   dcterms:contributor "Michael Ringel" ;
   dcterms:created "2020-07-15"^^xsd:date ;
   dcterms:creator "Steve Ray" ;
-  dcterms:modified "2023-08-11T10:39:23.751+00:00"^^xsd:dateTime ;
+  dcterms:modified "2023-07-28T10:54:47.359-04:00"^^xsd:dateTime ;
   dcterms:rights "The QUDT Ontologies are issued under a Creative Commons Attribution 4.0 International License (CC BY 4.0), available at https://creativecommons.org/licenses/by/4.0/. Attribution should be made to QUDT.org" ;
   dcterms:subject "Prefixes" ;
   dcterms:title "QUDT Prefixes Version 2.1 Vocabulary" ;
   vaem:description "The Prefixes vocabulary defines the prefixes commonly prepended to units to connote multiplication, either decimal or binary." ;
   vaem:graphName "prefix" ;
-  vaem:graphTitle "QUDT Prefixes Version 2.1.30" ;
+  vaem:graphTitle "QUDT Prefixes Version 2.1.29" ;
   vaem:hasGraphRole vaem:VocabularyGraph ;
   vaem:hasOwner <http://www.linkedmodel.org/schema/vaem#QUDT.org> ;
   vaem:hasSteward <http://www.linkedmodel.org/schema/vaem#QUDT.org> ;
@@ -425,5 +425,5 @@ vaem:GMD_QUDT-PREFIXES
   vaem:usesNonImportedResource dcterms:title ;
   vaem:website "http://qudt.org/2.1/vocab/prefix.ttl"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/prefix> ;
-  rdfs:label "QUDT Prefix Vocabulary Version Metadata 2.1.30" ;
+  rdfs:label "QUDT Prefix Vocabulary Version Metadata 2.1.29" ;
 .


### PR DESCRIPTION
As requested, the QUDT Prefix Vocabulary Version, which has been erroneously updated to version 2.1.30 during my last commit, was reverted to 2.1.29 for merging.